### PR TITLE
helm: may not need separate namespace for cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -248,7 +248,7 @@ OPERATOR_SDK ?= $(LOCALBIN)/operator-sdk
 KUSTOMIZE_VERSION ?= v3.8.7
 CONTROLLER_TOOLS_VERSION ?= v0.10.0
 HELMIFY_VERSION ?= v0.3.22
-CERTMANAGER_VERSION ?= v1.11.0
+CERTMANAGER_VERSION ?= 1.11.0
 OPERATOR_SDK_VERSION ?= 1.26.0
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"

--- a/README.md
+++ b/README.md
@@ -38,11 +38,12 @@ export REGISTRY_DOMAIN=localhost:5000
 ```
 
 ## Run the operator
-There are three ways to run the operator:
+There are four ways to run the operator:
 
 1. As a Go program outside a cluster
 2. As a Deployment inside a Kubernetes cluster
 3. Managed by the [Operator Lifecycle Manager (OLM)](https://sdk.operatorframework.io/docs/olm-integration/tutorial-bundle/#enabling-olm) in [bundle](https://sdk.operatorframework.io/docs/olm-integration/quickstart-bundle/) format
+4. Using [helm](https://helm.sh/)
 
 ### Run locally outside the cluster
 1. Generate certificates for local testing:
@@ -136,8 +137,34 @@ For example, using a local registry, the command becomes:
 operator-sdk run bundle localhost:5000/koor-operator-bundle:v0.0.1 --use-http
 ```
 
-### Create the KoorCluster Custom Resource
-Update the samples in `config/samples/...` to fit your needs, then create the Custom Resource:
+### Install using Helm
+1. Build and push your image to the registry. If `IMG` is not specified, it defaults to `$(REGISTRY_DOMAIN)/koor-operator:v$(VERSION)`:
+
+```sh
+make docker-build docker-push
+```
+
+2. Install `cert-manager` if not already installed:
+
+```sh
+make cert-manager
+```
+
+1. Install the helm chart to the cluster. Create a `values.yaml` file if necessary.
+
+```sh
+helm install koor-operator --namespace koor-operator --create-namespace charts/koor-operator
+```
+
+#### Uninstall helm chart
+To undeploy the controller from the cluster:
+
+```sh
+helm uninstall koor-operator --namespace koor-operator
+```
+
+## Create the KoorCluster Custom Resource
+When deploying the operator locally, as a deployment, or using the OLM, you need to create a KoorCluster custom resource. To do that, update the samples in `config/samples/...` to fit your needs, then create the Custom Resource:
 
 ```sh
 kubectl apply -f config/samples/storage_v1alpha1_koorcluster.yaml

--- a/charts/koor-operator/additional-values.yaml
+++ b/charts/koor-operator/additional-values.yaml
@@ -2,8 +2,6 @@
 # This is appeneded to values.yaml from additional-values.yaml. This is a hack to avoid getting these values overwritten by helmify
 
 koorCluster:
-  namespace: rook-ceph
-  createNamespace: true
   spec:
     useAllDevices: true
     monitoringEnabled: true

--- a/charts/koor-operator/templates/_koorcluster.tpl
+++ b/charts/koor-operator/templates/_koorcluster.tpl
@@ -7,7 +7,7 @@ kind: KoorCluster
 metadata:
   name: {{ include "koor-operator.fullname" . }}-koorcluster
   {{- if .Values.koorCluster.namespace }}
-  namespace: {{ .Values.koorCluster.namespace }}
+  namespace: {{ .Release.Namespace }}
   {{- end }}
   labels:
     app.kubernetes.io/created-by: koor-operator

--- a/charts/koor-operator/templates/koorcluster-postinstall-job.yaml
+++ b/charts/koor-operator/templates/koorcluster-postinstall-job.yaml
@@ -27,9 +27,6 @@ spec:
         args:
           - |-
             sleep 1;
-            {{- if and .Values.koorCluster.createNamespace .Values.koorCluster.namespace }}
-            kubectl create namespace {{ .Values.koorCluster.namespace }} --dry-run=client -o yaml | kubectl apply -f -;
-            {{- end }}
             cat <<EOF | kubectl apply -f -
             {{- include "koor-operator.koorCluster" . | nindent 12 }}
             EOF

--- a/charts/koor-operator/values.yaml
+++ b/charts/koor-operator/values.yaml
@@ -41,8 +41,6 @@ webhookService:
 # This is appeneded to values.yaml from additional-values.yaml. This is a hack to avoid getting these values overwritten by helmify
 
 koorCluster:
-  namespace: rook-ceph
-  createNamespace: true
   spec:
     useAllDevices: true
     monitoringEnabled: true


### PR DESCRIPTION
I tested it out. Using a separate namespace for the `KoorCluster` resource is not needed. This PR also adds helm install instructions to the readme file.