### PR TITLE
fix: use correct release name in finalizer

### DIFF
--- a/controllers/koorcluster_controller.go
+++ b/controllers/koorcluster_controller.go
@@ -296,16 +296,14 @@ func (r *KoorClusterReconciler) handleFinalizer(ctx context.Context, koorCluster
 		return nil
 	}
 
-	releaseName := koorCluster.Namespace + "-cluster"
+	releaseName := koorCluster.Namespace + "-rook-ceph-cluster"
 	if err := helmClient.UninstallReleaseByName(releaseName); err != nil {
 		log.Error(err, "Failed to uninstall release", "releaseName", releaseName)
-		return err
 	}
 
-	releaseName = koorCluster.Namespace
+	releaseName = koorCluster.Namespace + "-rook-ceph"
 	if err := helmClient.UninstallReleaseByName(releaseName); err != nil {
 		log.Error(err, "Failed to uninstall release", "releaseName", releaseName)
-		return err
 	}
 
 	// remove our finalizer from the list and update it.

--- a/controllers/koorcluster_controller_test.go
+++ b/controllers/koorcluster_controller_test.go
@@ -37,6 +37,8 @@ var _ = Describe("KoorCluster controller", func() {
 	const (
 		KoorClusterNamePrefix = "test-koorcluster-"
 		KoorClusterNamespace  = "default"
+		RookReleaseName       = KoorClusterNamespace + "-rook-ceph"
+		ClusterReleaseName    = KoorClusterNamespace + "-rook-ceph-cluster"
 
 		timeout  = time.Second * 10
 		duration = time.Second * 10
@@ -65,12 +67,12 @@ var _ = Describe("KoorCluster controller", func() {
 				mockHelmClient.EXPECT().UpdateChartRepos().Return(nil).Times(1),
 				mockHelmClient.EXPECT().InstallOrUpgradeChart(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).
 					DoAndReturn(func(ctx interface{}, chartSpec *hc.ChartSpec, opts interface{}) (interface{}, error) {
-						Expect(chartSpec.ReleaseName).To(Equal(KoorClusterNamespace + "-rook-ceph"))
+						Expect(chartSpec.ReleaseName).To(Equal(RookReleaseName))
 						return nil, nil
 					}),
 				mockHelmClient.EXPECT().InstallOrUpgradeChart(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).
 					DoAndReturn(func(ctx interface{}, chartSpec *hc.ChartSpec, opts interface{}) (interface{}, error) {
-						Expect(chartSpec.ReleaseName).To(Equal(KoorClusterNamespace + "-rook-ceph-cluster"))
+						Expect(chartSpec.ReleaseName).To(Equal(ClusterReleaseName))
 						return nil, nil
 					}),
 			)
@@ -170,12 +172,12 @@ var _ = Describe("KoorCluster controller", func() {
 				mockHelmClient.EXPECT().UpdateChartRepos().Return(nil).Times(1),
 				mockHelmClient.EXPECT().InstallOrUpgradeChart(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).
 					DoAndReturn(func(ctx interface{}, chartSpec *hc.ChartSpec, opts interface{}) (interface{}, error) {
-						Expect(chartSpec.ReleaseName).To(Equal(KoorClusterNamespace + "-rook-ceph"))
+						Expect(chartSpec.ReleaseName).To(Equal(RookReleaseName))
 						return nil, nil
 					}),
 				mockHelmClient.EXPECT().InstallOrUpgradeChart(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).
 					DoAndReturn(func(ctx interface{}, chartSpec *hc.ChartSpec, opts interface{}) (interface{}, error) {
-						Expect(chartSpec.ReleaseName).To(Equal(KoorClusterNamespace + "-rook-ceph-cluster"))
+						Expect(chartSpec.ReleaseName).To(Equal(ClusterReleaseName))
 						return nil, nil
 					}),
 			)
@@ -201,8 +203,8 @@ var _ = Describe("KoorCluster controller", func() {
 	Context("When finalizing a KoorCluster", func() {
 		It("Should uninstall the operator and the cluster helm charts", func() {
 			gomock.InOrder(
-				mockHelmClient.EXPECT().UninstallReleaseByName(KoorClusterNamespace+"-cluster").Return(nil).Times(1),
-				mockHelmClient.EXPECT().UninstallReleaseByName(KoorClusterNamespace).Return(nil).Times(1),
+				mockHelmClient.EXPECT().UninstallReleaseByName(ClusterReleaseName).Return(nil).Times(1),
+				mockHelmClient.EXPECT().UninstallReleaseByName(RookReleaseName).Return(nil).Times(1),
 			)
 
 			By("By creating a KoorCluster with Finalizer")


### PR DESCRIPTION
And skip errors in case the release is already deleted. This is safe to ignore because the code for uninstall only returns an error if the connection to k8s cannot be established or the release is not found. We also log the error.