### PR TITLE
ci: use action-gh-release

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -53,6 +53,13 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
+      - name: GitHub Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          generate_release_notes: true
+          draft: true
+
   build-bundle:
     name: Build and push bundle Docker image to Docker Hub
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,0 @@
-## 0.1.0 / 2023-03-30
-
-* [FEATURE] Initial release of `koor-operator`

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,13 +3,12 @@
 To create a new release (example is for release `v0.1.0`):
 
 1. Increase the version according to Semantic Versioning in the [`VERSION` file](VERSION).
-2. Add a new entry to the [`CHANGELOG.md`](CHANGELOG.md) with the changes and improvements listed in it.
-3. Run `make all` which updates `appVersion` in [the `Chart.yaml` of the helm chart.](charts/koor-operator/Chart.yaml) Update chart version.
-4. Check out a new branch, which will be used for the pull request to update the version: `git checkout -b BRANCH_NAME`
-5. Commit these changes now using `git commit -s -S`.
-6. Push the branch using `git push -u origin BRANCH_NAME` with these changes and create a pull request on [GitHub](https://github.com/koor-tech/koor-operator).
-7. Wait for pull request to be approved and merge it (if you have access to do so).
-8. Create the new tag using `git tag v0.1.0` and then run `git push -u origin v0.1.0`
-9. In a few minutes, the CI should have built and published a draft of the release here [GitHub - Releases List](https://github.com/koor-tech/koor-operator/releases).
-10. Now edit the release and use the green button to publish the release.
-11. Congratulations! The release is now fully published.
+2. Run `make all` which updates `appVersion` in [the `Chart.yaml` of the helm chart.](charts/koor-operator/Chart.yaml) Update chart version.
+3. Check out a new branch, which will be used for the pull request to update the version: `git checkout -b BRANCH_NAME`
+4. Commit these changes now using `git commit -s -S`.
+5. Push the branch using `git push -u origin BRANCH_NAME` with these changes and create a pull request on [GitHub](https://github.com/koor-tech/koor-operator).
+6. Wait for pull request to be approved and merge it (if you have access to do so).
+7. Create the new tag using `git tag v0.1.0` and then run `git push -u origin v0.1.0`
+8. In a few minutes, the CI should have built and published a draft of the release here [GitHub - Releases List](https://github.com/koor-tech/koor-operator/releases).
+9. Now edit the release and use the green button to publish the release.
+10. Congratulations! The release is now fully published.


### PR DESCRIPTION
Use [softprops/action-gh-release](https://github.com/softprops/action-gh-release) which creates a GitHub release. There is no need to maintain a CHANGELOG.md since GitHub autogenerates the release notes.