### PR TITLE
helm: add cert-manager as subchart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,9 +120,10 @@ local-certs: ## Generate the certs required to run webhooks locally
 .PHONY: helm
 helm: manifests kustomize helmify ## Generate the koor-operator helm chart
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	$(KUSTOMIZE) build config/default | $(HELMIFY) -v -image-pull-secrets charts/koor-operator
+	$(KUSTOMIZE) build config/default | $(HELMIFY) -v -cert-manager-as-subchart charts/koor-operator
 	cat charts/koor-operator/additional-values.yaml >> charts/koor-operator/values.yaml
 	sed -i 's/^\(appVersion: \).*/\1"v$(VERSION)"/' charts/koor-operator/Chart.yaml
+	sed -i 's/^\certManager:/certmanager:/' charts/koor-operator/values.yaml
 
 
 .PHONY: ensure-generate-is-noop
@@ -252,7 +253,7 @@ OPERATOR_SDK ?= $(LOCALBIN)/operator-sdk
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v3.8.7
 CONTROLLER_TOOLS_VERSION ?= v0.10.0
-HELMIFY_VERSION ?= v0.3.22
+HELMIFY_VERSION ?= v0.3.34
 CERTMANAGER_VERSION ?= 1.11.0
 OPERATOR_SDK_VERSION ?= 1.26.0
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ make uninstall
 ```
 
 ### Running as a Deployment inside the cluster
-1. Build and push your image to the registry. If `IMG` is not specified, it defaults to `$(REGISTRY_DOMAIN)/koor-operator:v$(VERSION)`:
+1. Build and push your image to the registry. If `IMG` is not specified, it defaults to `$(REGISTRY_HOST)/koor-operator:v$(VERSION)`:
 
 ```sh
 make docker-build docker-push
@@ -113,7 +113,7 @@ make undeploy-cert-manager
 operator-sdk olm install
 ```
 
-2. Build and push your image to the registry. If `IMG` is not specified, it defaults to `$(REGISTRY_DOMAIN)/koor-operator:v$(VERSION)`:
+2. Build and push your image to the registry. If `IMG` is not specified, it defaults to `$(REGISTRY_HOST)/koor-operator:v$(VERSION)`:
 
 ```sh
 make docker-build docker-push
@@ -138,19 +138,13 @@ operator-sdk run bundle localhost:5000/koor-operator-bundle:v0.0.1 --use-http
 ```
 
 ### Install using Helm
-1. Build and push your image to the registry. If `IMG` is not specified, it defaults to `$(REGISTRY_DOMAIN)/koor-operator:v$(VERSION)`:
+1. Build and push your image to the registry. If `IMG` is not specified, it defaults to `$(REGISTRY_HOST)/koor-operator:v$(VERSION)`:
 
 ```sh
 make docker-build docker-push
 ```
 
-2. Install `cert-manager` if not already installed:
-
-```sh
-make cert-manager
-```
-
-1. Install the helm chart to the cluster. Create a `values.yaml` file if necessary.
+2. Install the helm chart to the cluster. Create a `values.yaml` file if necessary.
 
 ```sh
 helm install koor-operator --namespace koor-operator --create-namespace charts/koor-operator

--- a/bundle/manifests/koor-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/koor-operator.clusterserviceversion.yaml
@@ -27,7 +27,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2023-03-30T06:08:24Z"
+    createdAt: "2023-03-30T21:03:26Z"
     operators.operatorframework.io/builder: operator-sdk-v1.26.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: koor-operator.v0.1.0
@@ -199,10 +199,10 @@ spec:
                 resources:
                   limits:
                     cpu: 500m
-                    memory: 128Mi
+                    memory: 512Mi
                   requests:
                     cpu: 10m
-                    memory: 64Mi
+                    memory: 128Mi
                 securityContext:
                   allowPrivilegeEscalation: false
                   capabilities:

--- a/charts/koor-operator/.gitignore
+++ b/charts/koor-operator/.gitignore
@@ -1,0 +1,3 @@
+index.yaml
+*.tgz
+Chart.lock

--- a/charts/koor-operator/Chart.yaml
+++ b/charts/koor-operator/Chart.yaml
@@ -27,3 +27,10 @@ appVersion: "v0.1.0"
 # Helm will validate the version constraints when installing the chart and fail if the cluster
 # runs an unsupported Kubernetes version.
 kubeVersion: ">=1.19.0"
+
+dependencies:
+  - name: cert-manager
+    repository: https://charts.jetstack.io
+    version: v1.11.0
+    condition: certmanager.enabled
+    alias: certmanager

--- a/charts/koor-operator/templates/_koorcluster.tpl
+++ b/charts/koor-operator/templates/_koorcluster.tpl
@@ -16,3 +16,10 @@ metadata:
 spec:
 {{ toYaml .Values.koorCluster.spec | indent 2 }}
 {{- end }}
+
+{{/*
+Koor cluster job that installs the custom resource
+*/}}
+{{- define "koor-operator.jobName" -}}
+{{- include "koor-operator.fullname" . }}-koorcluster-job
+{{- end }}

--- a/charts/koor-operator/templates/deployment.yaml
+++ b/charts/koor-operator/templates/deployment.yaml
@@ -56,7 +56,7 @@ spec:
         - --v=0
         env:
         - name: KUBERNETES_CLUSTER_DOMAIN
-          value: {{ .Values.kubernetesClusterDomain }}
+          value: {{ quote .Values.kubernetesClusterDomain }}
         image: {{ .Values.controllerManager.kubeRbacProxy.image.repository }}:{{ .Values.controllerManager.kubeRbacProxy.image.tag
           | default .Chart.AppVersion }}
         name: kube-rbac-proxy
@@ -66,11 +66,8 @@ spec:
           protocol: TCP
         resources: {{- toYaml .Values.controllerManager.kubeRbacProxy.resources | nindent
           10 }}
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
+        securityContext: {{- toYaml .Values.controllerManager.kubeRbacProxy.containerSecurityContext
+          | nindent 10 }}
       - args:
         - --health-probe-bind-address=:8081
         - --metrics-bind-address=127.0.0.1:8080
@@ -79,7 +76,7 @@ spec:
         - /manager
         env:
         - name: KUBERNETES_CLUSTER_DOMAIN
-          value: {{ .Values.kubernetesClusterDomain }}
+          value: {{ quote .Values.kubernetesClusterDomain }}
         image: {{ .Values.controllerManager.manager.image.repository }}:{{ .Values.controllerManager.manager.image.tag
           | default .Chart.AppVersion }}
         livenessProbe:
@@ -101,16 +98,12 @@ spec:
           periodSeconds: 10
         resources: {{- toYaml .Values.controllerManager.manager.resources | nindent 10
           }}
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
+        securityContext: {{- toYaml .Values.controllerManager.manager.containerSecurityContext
+          | nindent 10 }}
         volumeMounts:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
           readOnly: true
-      imagePullSecrets: {{ .Values.imagePullSecrets | default list | toJson }}
       securityContext:
         runAsNonRoot: true
       serviceAccountName: {{ include "koor-operator.fullname" . }}-controller-manager

--- a/charts/koor-operator/templates/job-rbac.yaml
+++ b/charts/koor-operator/templates/job-rbac.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "koor-operator.fullname" . }}-koorcluster-job
+  name: {{ include "koor-operator.jobName" . }}
   labels:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: koor-operator
@@ -54,5 +54,5 @@ roleRef:
   name: '{{ include "koor-operator.fullname" . }}-job-role'
 subjects:
 - kind: ServiceAccount
-  name: '{{ include "koor-operator.fullname" . }}-koorcluster-job'
+  name: '{{ include "koor-operator.jobName" . }}'
   namespace: '{{ .Release.Namespace }}'

--- a/charts/koor-operator/templates/koorcluster-job.yaml
+++ b/charts/koor-operator/templates/koorcluster-job.yaml
@@ -1,23 +1,20 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "koor-operator.fullname" . }}-koorcluster-job
+  name: {{ include "koor-operator.jobName" . }}
   labels:
     app.kubernetes.io/created-by: koor-operator
     app.kubernetes.io/part-of: koor-operator
     {{- include "koor-operator.labels" . | nindent 4 }}
-  annotations:
-    helm.sh/hook: post-install,post-upgrade,post-rollback
-    helm.sh/hook-delete-policy: hook-succeeded
 spec:
   template:
     metadata:
-      name: {{ include "koor-operator.fullname" . }}-koorcluster-job
+      name: {{ include "koor-operator.jobName" . }}
       labels:
         {{- include "koor-operator.labels" . | nindent 8 }}
     spec:
       restartPolicy: OnFailure
-      serviceAccountName: {{ include "koor-operator.fullname" . }}-koorcluster-job
+      serviceAccountName: {{ include "koor-operator.jobName" . }}
       containers:
       - name: {{ include "koor-operator.fullname" . }}-koorcluster-install-job
         image: bitnami/kubectl:1.25.6

--- a/charts/koor-operator/templates/koorcluster-predelete-job.yaml
+++ b/charts/koor-operator/templates/koorcluster-predelete-job.yaml
@@ -17,7 +17,7 @@ spec:
         {{- include "koor-operator.labels" . | nindent 8 }}
     spec:
       restartPolicy: OnFailure
-      serviceAccountName: {{ include "koor-operator.fullname" . }}-koorcluster-job
+      serviceAccountName: {{ include "koor-operator.jobName" . }}
       containers:
       - name: {{ include "koor-operator.fullname" . }}-koorcluster-delete-job
         image: bitnami/kubectl:1.25.6
@@ -26,6 +26,7 @@ spec:
           - "-c"
         args:
           - |-
+            kubectl delete -n job {{ include "koor-operator.jobName" . }} --ignore-not-found
             cat <<EOF | kubectl delete -f - --ignore-not-found
             {{- include "koor-operator.koorCluster" . | nindent 12}}
             EOF

--- a/charts/koor-operator/templates/selfsigned-issuer.yaml
+++ b/charts/koor-operator/templates/selfsigned-issuer.yaml
@@ -2,6 +2,9 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: {{ include "koor-operator.fullname" . }}-selfsigned-issuer
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "1"
   labels:
   {{- include "koor-operator.labels" . | nindent 4 }}
 spec:

--- a/charts/koor-operator/templates/serving-cert.yaml
+++ b/charts/koor-operator/templates/serving-cert.yaml
@@ -2,6 +2,9 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ include "koor-operator.fullname" . }}-serving-cert
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "2"
   labels:
   {{- include "koor-operator.labels" . | nindent 4 }}
 spec:

--- a/charts/koor-operator/values.yaml
+++ b/charts/koor-operator/values.yaml
@@ -1,5 +1,13 @@
+certManager:
+  enabled: true
+  installCRDs: true
 controllerManager:
   kubeRbacProxy:
+    containerSecurityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
     image:
       repository: gcr.io/kubebuilder/kube-rbac-proxy
       tag: v0.13.0
@@ -11,18 +19,22 @@ controllerManager:
         cpu: 5m
         memory: 64Mi
   manager:
+    containerSecurityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
     image:
       repository: docker.io/koorinc/koor-operator
       tag: v0.1.0
     resources:
       limits:
         cpu: 500m
-        memory: 128Mi
+        memory: 512Mi
       requests:
         cpu: 10m
-        memory: 64Mi
+        memory: 128Mi
   replicas: 1
-imagePullSecrets: []
 kubernetesClusterDomain: cluster.local
 metricsService:
   ports:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -37,7 +37,7 @@ spec:
         control-plane: controller-manager
     spec:
       # TODO(user): Uncomment the following code to configure the nodeAffinity expression
-      # according to the platforms which are supported by your solution. 
+      # according to the platforms which are supported by your solution.
       # It is considered best practice to support multiple architectures. You can
       # build your manager image using the makefile target docker-buildx.
       # affinity:
@@ -94,9 +94,9 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 128Mi
+            memory: 512Mi
           requests:
             cpu: 10m
-            memory: 64Mi
+            memory: 128Mi
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/utils/clusterValues.yaml
+++ b/utils/clusterValues.yaml
@@ -1,5 +1,5 @@
 # Namespace of the main rook operator
-operatorNamespace: {{ .Namespace }}-rook-ceph
+operatorNamespace: {{ .Namespace }}
 
 # Ability to override ceph.conf
 configOverride: |


### PR DESCRIPTION
Adding helm manager as a subchart is a way to reduce the overhead when installing the koor-operator via helm. No need to install cert-manager separately now. Tried in [vineyard operator](https://github.com/v6d-io/v6d/blob/b897b76c52dea409a3a84ad6b751a9b22980257e/charts/vineyard-operator/Chart.yaml#L34-L38) and uses `-cert-manager-as-subchart` option from [helmify](https://github.com/arttor/helmify#available-options).

This also makes sure that installing the chart is non-blocking.

Resolves: KSD-156
Resolves: KSD-190