### PR TITLE
helm: update chart version to resolve ci issue

### DIFF
--- a/charts/koor-operator/Chart.yaml
+++ b/charts/koor-operator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.3
+version: 0.1.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
Seems that even with the CI being green in the PR #65, now failing on `main` branch:
https://github.com/koor-tech/koor-operator/actions/runs/5047130671/jobs/9053559321