### PR TITLE
ci: autotag and only publish helm on tags

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -18,6 +18,13 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v3
 
+      # Extract version data and create tag
+      - uses: jaliborc/action-general-autotag@1.0.0
+        with:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          source_file: "VERSION"
+          extraction_regex: "(.*)"
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
@@ -63,6 +70,7 @@ jobs:
   build-bundle:
     name: Build and push bundle Docker image to Docker Hub
     runs-on: ubuntu-latest
+    needs: build
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3

--- a/.github/workflows/helm-publish.yml
+++ b/.github/workflows/helm-publish.yml
@@ -2,8 +2,8 @@ name: Release Charts
 
 on:
   push:
-    branches:
-      - main
+    tags:
+      - 'v*'
 
 jobs:
   release:
@@ -12,6 +12,7 @@ jobs:
     permissions:
       contents: write
     runs-on: ubuntu-latest
+    needs: build
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,12 +3,11 @@
 To create a new release (example is for release `v0.1.0`):
 
 1. Increase the version according to Semantic Versioning in the [`VERSION` file](VERSION).
-2. Run `make all` which updates `appVersion` in [the `Chart.yaml` of the helm chart.](charts/koor-operator/Chart.yaml) Update chart version.
+2. Run `make` which updates `version` and `appVersion` in [the `Chart.yaml` of the helm chart.](charts/koor-operator/Chart.yaml)
 3. Check out a new branch, which will be used for the pull request to update the version: `git checkout -b BRANCH_NAME`
 4. Commit these changes now using `git commit -s -S`.
 5. Push the branch using `git push -u origin BRANCH_NAME` with these changes and create a pull request on [GitHub](https://github.com/koor-tech/koor-operator).
 6. Wait for pull request to be approved and merge it (if you have access to do so).
-7. Create the new tag using `git tag v0.1.0` and then run `git push -u origin v0.1.0`
-8. In a few minutes, the CI should have built and published a draft of the release here [GitHub - Releases List](https://github.com/koor-tech/koor-operator/releases).
-9. Now edit the release and use the green button to publish the release.
-10. Congratulations! The release is now fully published.
+7. In a few minutes, the CI should have built and published a draft of the release here [GitHub - Releases List](https://github.com/koor-tech/koor-operator/releases).
+8. Now edit the release and use the green button to publish the release.
+9. Congratulations! The release is now fully published.


### PR DESCRIPTION
If this works, it could make the release process cleaner